### PR TITLE
fix: Add function arg to call at end of animation

### DIFF
--- a/app/src/main/java/be/hogent/faith/faith/mainScreen/MainScreenFragment.kt
+++ b/app/src/main/java/be/hogent/faith/faith/mainScreen/MainScreenFragment.kt
@@ -40,10 +40,10 @@ class MainScreenFragment : Fragment() {
     override fun onStart() {
         super.onStart()
         mainScreenViewModel.firstLocation.observe(this, Observer {
-            moveAvatarToLocationOf(mainScreenBinding.mainFirstLocation)
+            moveAvatarToLocationOf(mainScreenBinding.mainFirstLocation) {}
         })
         mainScreenViewModel.secondLocation.observe(this, Observer {
-            moveAvatarToLocationOf(mainScreenBinding.mainSecondLocation)
+            moveAvatarToLocationOf(mainScreenBinding.mainSecondLocation) { navigation.startEventDetailsFragment() }
         })
     }
 
@@ -53,9 +53,10 @@ class MainScreenFragment : Fragment() {
     }
 
     /**
-     * Moves the avatar to the top-left corner of the given view.
+     * Moves the avatar View to the top-left corner of the given View.
+     * Once the animation is finished it calls the [onAnimationEndCall].
      */
-    private fun moveAvatarToLocationOf(view: View) {
+    private fun moveAvatarToLocationOf(view: View, onAnimationEndCall: () -> Unit) {
         // No need to animate if the avatar is already there
         if (avatarView.x == view.x && avatarView.y == view.y) {
             Log.i(TAG, "Not moving the avatar as we're already at the view's location")
@@ -74,7 +75,7 @@ class MainScreenFragment : Fragment() {
             addListener(object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator?) {
                     super.onAnimationEnd(animation)
-                    navigation.startEventDetailsFragment()
+                    onAnimationEndCall()
                 }
             })
         }

--- a/app/src/main/res/layout/fragment_main_screen.xml
+++ b/app/src/main/res/layout/fragment_main_screen.xml
@@ -29,7 +29,7 @@
                 android:contentDescription="@string/frag_main_descr_your_avatar"/>
 
         <!-- KNOPPEN -->
-        <!-- Invisibile to make it transaparent -->
+        <!-- Invisibile to make it transparent -->
         <androidx.constraintlayout.widget.ConstraintLayout
                 xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"


### PR DESCRIPTION
Previously every call to moveAvatarToLocationOf triggered the same
fragment opening.
This was made more generic by providing an extra argument to that
function which specificies the action to do once the animation is done.
This allows you to open whatever fragment you like, or do another action.
This could be a possible way to animate moving to several points on the
map.

FAITH-27