### PR TITLE
BF: undo/redo werkt niet altijd. knoppen vergroot

### DIFF
--- a/app/src/main/res/layout/panel_drawing_undo_redo.xml
+++ b/app/src/main/res/layout/panel_drawing_undo_redo.xml
@@ -23,8 +23,8 @@
 
             <ImageButton
                 android:id="@+id/btn_draw_undo"
-                android:layout_width="32dp"
-                android:layout_height="23dp"
+                android:layout_width="@dimen/material_icon_width"
+                android:layout_height="@dimen/material_icon_width"
                 android:layout_margin="16dp"
                 android:background="@drawable/ic_undo"
                 android:contentDescription="@string/undo"
@@ -37,8 +37,8 @@
 
             <ImageButton
                 android:id="@+id/btn_draw_redo"
-                android:layout_width="32dp"
-                android:layout_height="23dp"
+                android:layout_width="@dimen/material_icon_width"
+                android:layout_height="@dimen/material_icon_width"
                 android:layout_margin="16dp"
                 android:background="@drawable/ic_redo"
                 android:contentDescription="@string/redo"


### PR DESCRIPTION
Ik heb de knoppen een size van 48dp gegeven, het minimum zoals aangegeven in android design guidelines