### PR TITLE
refactor/fix: for io thread when building observables in GetUserUseCase

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -39,7 +39,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8 (4)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/be/hogent/faith/faith/UserViewModel.kt
+++ b/app/src/main/java/be/hogent/faith/faith/UserViewModel.kt
@@ -26,10 +26,6 @@ class UserViewModel(
     private val getUserUseCase: GetUserUseCase
 ) : ViewModel() {
 
-    private var userName: String? = null
-    private var password: String? = null
-    private var avatar: String? = null
-
     private val _eventSavedState = MutableLiveData<Resource<Unit>>()
     val eventSavedState: LiveData<Resource<Unit>>
         get() = _eventSavedState

--- a/service/src/main/java/be/hogent/faith/service/di/ServiceModule.kt
+++ b/service/src/main/java/be/hogent/faith/service/di/ServiceModule.kt
@@ -26,7 +26,6 @@ import be.hogent.faith.service.usecases.user.GetUserUseCase
 import be.hogent.faith.service.usecases.user.IsUsernameUniqueUseCase
 import be.hogent.faith.service.usecases.user.LoginUserUseCase
 import be.hogent.faith.service.usecases.user.LogoutUserUseCase
-import io.reactivex.schedulers.Schedulers
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -47,8 +46,21 @@ object CinemaNames {
 }
 
 val serviceModule = module {
-    factory { GetEventsUseCase(get(), get(), get()) }
-    factory { SaveEventUseCase(get(), get(), get(), get()) }
+    factory {
+        GetEventsUseCase(
+            eventRepository = get(),
+            eventEncryptionService = get(),
+            observer = get()
+        )
+    }
+    factory {
+        SaveEventUseCase(
+            eventEncryptionService = get(),
+            filesStorageRepository = get(),
+            eventRepository = get(),
+            observer = get()
+        )
+    }
     factory {
         CreateUserUseCase(
             authManager = get(),
@@ -57,13 +69,20 @@ val serviceModule = module {
             cinemaRepository = get(named(CinemaNames.repo)),
             backpackEncryptionService = get(),
             cinemaEncryptionService = get(),
-            observer = get(),
-            subscriber = Schedulers.io()
+            observer = get()
         )
     }
     factory { SaveEmotionAvatarUseCase(get(), get()) }
     factory { SaveEventDetailUseCase(get(), get()) }
-    factory { GetUserUseCase(get(), get(), get(), get(), get()) }
+    factory {
+        GetUserUseCase(
+            userRepository = get(),
+            eventRepository = get(),
+            eventEncryptionService = get(),
+            authManager = get(),
+            observeScheduler = get()
+        )
+    }
     factory { IsUsernameUniqueUseCase(get(), get()) }
     factory { LoginUserUseCase(get(), get()) }
     factory { LogoutUserUseCase(get(), get()) }
@@ -76,13 +95,20 @@ val serviceModule = module {
     factory { CreateTextDetailUseCase(get(), get()) }
     factory { CreateExternalVideoDetailUseCase(get()) }
     factory { DeleteEventDetailUseCase(get()) }
-    factory { MakeEventFilesAvailableUseCase(get(), get(), get(), get(), Schedulers.io()) }
+    factory {
+        MakeEventFilesAvailableUseCase(
+            fileStorageRepo = get(),
+            eventRepository = get(),
+            eventEncryptionService = get(),
+            observer = get()
+        )
+    }
     factory<LoadDetailFileUseCase<Backpack>>(named("LoadBackpackDetailFileUseCase")) {
         LoadDetailFileUseCase<Backpack>(
             storageRepo = get(),
             containerRepository = get(named(BackpackNames.repo)),
             detailContainerEncryptionService = get(named(BackpackNames.encryptionService)),
-            observeScheduler = get()
+            observer = get()
         )
     }
     factory<LoadDetailFileUseCase<Cinema>>(named("LoadCinemaDetailFileUseCase")) {
@@ -90,17 +116,21 @@ val serviceModule = module {
             storageRepo = get(),
             containerRepository = get(named(CinemaNames.repo)),
             detailContainerEncryptionService = get(named(CinemaNames.encryptionService)),
-            observeScheduler = get()
+            observer = get()
         )
     }
-    factory { GetYoutubeVideosFromSearchUseCase(get()) }
+    factory {
+        GetYoutubeVideosFromSearchUseCase(
+            observer = get(named("observer")),
+            subscriber = get(named("subscriber"))
+        )
+    }
     factory<SaveDetailsContainerDetailUseCase<Backpack>>(named("SaveBackpackDetailUseCase")) {
         SaveDetailsContainerDetailUseCase<Backpack>(
             detailContainerRepository = get(named(BackpackNames.repo)),
             detailContainerEncryptionService = get(named(BackpackNames.encryptionService)),
             storageRepository = get(),
-            observeScheduler = get(),
-            subscribeScheduler = Schedulers.io()
+            observer = get()
         )
     }
     factory<SaveDetailsContainerDetailUseCase<Cinema>>(named("SaveCinemaDetailUseCase")) {
@@ -108,36 +138,35 @@ val serviceModule = module {
             detailContainerRepository = get(named(CinemaNames.repo)),
             detailContainerEncryptionService = get(named(CinemaNames.encryptionService)),
             storageRepository = get(),
-            observeScheduler = get(),
-            subscribeScheduler = Schedulers.io()
+            observer = get()
         )
     }
-    factory<DeleteDetailsContainerDetailUseCase<Backpack>>(named("DeleteBackpackDetailUseCase")) {
+    factory<DeleteDetailsContainerDetailUseCase<Backpack>>(qualifier = named("DeleteBackpackDetailUseCase")) {
         DeleteDetailsContainerDetailUseCase<Backpack>(
             backpackRepository = get(named(BackpackNames.repo)),
-            fileStorageRepository = get(), observeScheduler = get()
+            fileStorageRepository = get(),
+            observer = get()
         )
     }
     factory<DeleteDetailsContainerDetailUseCase<Cinema>>(named("DeleteCinemaDetailUseCase")) {
         DeleteDetailsContainerDetailUseCase<Cinema>(
             backpackRepository = get(named(CinemaNames.repo)),
-            fileStorageRepository = get(), observeScheduler = get()
+            fileStorageRepository = get(),
+            observer = get()
         )
     }
     factory<GetDetailsContainerDataUseCase<Backpack>>(named("GetBackpackDataUseCase")) {
         GetDetailsContainerDataUseCase<Backpack>(
             detailsContainerRepository = get(named(BackpackNames.repo)),
             detailContainerEncryptionService = get(named(BackpackNames.encryptionService)),
-            observeScheduler = get(),
-            subscribeScheduler = Schedulers.io()
+            observer = get()
         )
     }
-    factory <GetDetailsContainerDataUseCase<Cinema>>(named("GetCinemaDataUseCase")) {
+    factory<GetDetailsContainerDataUseCase<Cinema>>(named("GetCinemaDataUseCase")) {
         GetDetailsContainerDataUseCase<Cinema>(
             detailsContainerRepository = get(named(CinemaNames.repo)),
             detailContainerEncryptionService = get(named(CinemaNames.encryptionService)),
-            observeScheduler = get(),
-            subscribeScheduler = Schedulers.io()
+            observer = get()
         )
     }
 }

--- a/service/src/main/java/be/hogent/faith/service/usecases/backpack/GetYoutubeVideosFromSearchUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/backpack/GetYoutubeVideosFromSearchUseCase.kt
@@ -9,8 +9,11 @@ import io.reactivex.Flowable
 import io.reactivex.Scheduler
 
 class GetYoutubeVideosFromSearchUseCase(
-    observeScheduler: Scheduler
-) : FlowableUseCase<List<YoutubeVideoDetail>, GetYoutubeVideosFromSearchUseCase.Params>(observeScheduler) {
+    observer: Scheduler,
+    subscriber: Scheduler
+) : FlowableUseCase<List<YoutubeVideoDetail>, GetYoutubeVideosFromSearchUseCase.Params>(
+    observer, subscriber
+) {
 
     private val VIDEOPART = "snippet"
     private val SAFESEARCH = "strict"
@@ -24,7 +27,14 @@ class GetYoutubeVideosFromSearchUseCase(
      * */
     override fun buildUseCaseObservable(params: Params): Flowable<List<YoutubeVideoDetail>> {
         return YoutubeApi.apiService.getYouTubeVideosAsync(
-            YoutubeConfig().getKey(), VIDEOPART, params.searchString, SAFESEARCH, TYPE, MAXRESULTS, FIELDS)
+            apiKey = YoutubeConfig().getKey(),
+            videoPart = VIDEOPART,
+            searchString = params.searchString,
+            safeSearch = SAFESEARCH,
+            type = TYPE,
+            maxResults = MAXRESULTS,
+            fields = FIELDS
+        )
             .map {
                 asDomainModel(it.items)
             }

--- a/service/src/main/java/be/hogent/faith/service/usecases/base/CompletableUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/base/CompletableUseCase.kt
@@ -16,7 +16,8 @@ import io.reactivex.schedulers.Schedulers
  * An example can be found in [be.hogent.faith.service.usecases.SaveEventUseCase].
  */
 abstract class CompletableUseCase<in Params>(
-    private val observer: Scheduler
+    private val observer: Scheduler,
+    protected val subscriber: Scheduler = Schedulers.io()
 ) {
 
     private val disposables = CompositeDisposable()
@@ -32,7 +33,7 @@ abstract class CompletableUseCase<in Params>(
      */
     open fun execute(params: Params, completableObserver: DisposableCompletableObserver) {
         val completable = this.buildUseCaseObservable(params)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(subscriber)
             .observeOn(observer)
         addDisposable(completable.subscribeWith(completableObserver))
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/base/FlowableUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/base/FlowableUseCase.kt
@@ -16,7 +16,8 @@ import io.reactivex.subscribers.DisposableSubscriber
  * An example can be found in [be.hogent.faith.service.usecases.SaveEventUseCase].
  */
 abstract class FlowableUseCase<Result, in Params>(
-    private val observer: Scheduler
+    private val observer: Scheduler,
+    protected val subscriber: Scheduler = Schedulers.io()
 ) {
 
     private val disposables = CompositeDisposable()
@@ -32,7 +33,7 @@ abstract class FlowableUseCase<Result, in Params>(
      */
     open fun execute(params: Params, flowableObserver: DisposableSubscriber<Result>) {
         val flowable = this.buildUseCaseObservable(params)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(subscriber)
             .observeOn(observer)
         addDisposable(flowable.subscribeWith(flowableObserver))
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/base/MaybeUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/base/MaybeUseCase.kt
@@ -17,7 +17,8 @@ import io.reactivex.schedulers.Schedulers
  * An example can be found in [be.hogent.faith.service.usecases.SaveEventUseCase].
  */
 abstract class MaybeUseCase<Result, in Params>(
-    private val observer: Scheduler
+    private val observer: Scheduler,
+    protected val subscriber: Scheduler = Schedulers.io()
 ) {
     private val disposables = CompositeDisposable()
 
@@ -25,7 +26,7 @@ abstract class MaybeUseCase<Result, in Params>(
 
     open fun execute(params: Params, singleObserver: DisposableMaybeObserver<Result>) {
         val single = this.buildUseCaseMaybe(params)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(subscriber)
             .observeOn(observer)
         addDisposable(single.subscribeWith(singleObserver))
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/base/ObservableUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/base/ObservableUseCase.kt
@@ -16,7 +16,8 @@ import io.reactivex.schedulers.Schedulers
  * An example can be found in [be.hogent.faith.service.usecases.SaveEventUseCase].
  */
 abstract class ObservableUseCase<Result, in Params>(
-    private val observer: Scheduler
+    private val observer: Scheduler,
+    protected val subscriber: Scheduler = Schedulers.io()
 ) {
 
     private val disposables = CompositeDisposable()
@@ -32,7 +33,7 @@ abstract class ObservableUseCase<Result, in Params>(
      */
     open fun execute(params: Params, observableObserver: DisposableObserver<Result>) {
         val observable = this.buildUseCaseObservable(params)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(subscriber)
             .observeOn(observer)
         addDisposable(observable.subscribeWith(observableObserver))
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/base/SingleUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/base/SingleUseCase.kt
@@ -16,7 +16,8 @@ import io.reactivex.schedulers.Schedulers
  * An example can be found in [be.hogent.faith.service.usecases.SaveEventUseCase].
  */
 abstract class SingleUseCase<Result, in Params>(
-    private val observer: Scheduler
+    private val observer: Scheduler,
+    protected val subscriber: Scheduler = Schedulers.io()
 ) {
     private val disposables = CompositeDisposable()
 
@@ -24,7 +25,7 @@ abstract class SingleUseCase<Result, in Params>(
 
     open fun execute(params: Params, singleObserver: DisposableSingleObserver<Result>) {
         val single = this.buildUseCaseSingle(params)
-            .subscribeOn(Schedulers.io())
+            .subscribeOn(subscriber)
             .observeOn(observer)
         addDisposable(single.subscribeWith(singleObserver))
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/detail/drawingDetail/CreateDrawingDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detail/drawingDetail/CreateDrawingDetailUseCase.kt
@@ -9,8 +9,8 @@ import io.reactivex.Single
 
 class CreateDrawingDetailUseCase(
     private val storageRepository: ITemporaryFileStorageRepository,
-    observeScheduler: Scheduler
-) : SingleUseCase<DrawingDetail, CreateDrawingDetailUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : SingleUseCase<DrawingDetail, CreateDrawingDetailUseCase.Params>(observer) {
 
     override fun buildUseCaseSingle(params: Params): Single<DrawingDetail> {
         return storageRepository.storeBitmap(params.bitmap)

--- a/service/src/main/java/be/hogent/faith/service/usecases/detail/drawingDetail/OverwriteDrawingDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detail/drawingDetail/OverwriteDrawingDetailUseCase.kt
@@ -13,10 +13,9 @@ import io.reactivex.Scheduler
  */
 class OverwriteDrawingDetailUseCase(
     private val storageRepo: ITemporaryFileStorageRepository,
-    observeScheduler: Scheduler
-) : CompletableUseCase<OverwriteDrawingDetailUseCase.Params>(
-    observeScheduler
-) {
+    observer: Scheduler
+) : CompletableUseCase<OverwriteDrawingDetailUseCase.Params>(observer) {
+
     override fun buildUseCaseObservable(params: Params): Completable {
         return storageRepo.overwriteExistingDrawingDetail(params.bitmap, params.detail)
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/detail/externalVideo/CreateExternalVideoDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detail/externalVideo/CreateExternalVideoDetailUseCase.kt
@@ -7,8 +7,8 @@ import io.reactivex.Single
 import java.io.File
 
 class CreateExternalVideoDetailUseCase(
-    observeScheduler: Scheduler
-) : SingleUseCase<ExternalVideoDetail, CreateExternalVideoDetailUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : SingleUseCase<ExternalVideoDetail, CreateExternalVideoDetailUseCase.Params>(observer) {
 
     override fun buildUseCaseSingle(params: Params): Single<ExternalVideoDetail> {
         return Single.fromCallable { ExternalVideoDetail(params.tempExternalVideoSaveFile) }

--- a/service/src/main/java/be/hogent/faith/service/usecases/detail/photoDetail/CreatePhotoDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detail/photoDetail/CreatePhotoDetailUseCase.kt
@@ -7,8 +7,8 @@ import io.reactivex.Single
 import java.io.File
 
 class CreatePhotoDetailUseCase(
-    observeScheduler: Scheduler
-) : SingleUseCase<PhotoDetail, CreatePhotoDetailUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : SingleUseCase<PhotoDetail, CreatePhotoDetailUseCase.Params>(observer) {
 
     override fun buildUseCaseSingle(params: Params): Single<PhotoDetail> {
         return Single.fromCallable { PhotoDetail(params.tempPhotoSaveFile) }

--- a/service/src/main/java/be/hogent/faith/service/usecases/detail/textDetail/CreateTextDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detail/textDetail/CreateTextDetailUseCase.kt
@@ -8,8 +8,8 @@ import io.reactivex.Single
 
 class CreateTextDetailUseCase(
     private val tempStorageRepo: ITemporaryFileStorageRepository,
-    observeScheduler: Scheduler
-) : SingleUseCase<TextDetail, CreateTextDetailUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : SingleUseCase<TextDetail, CreateTextDetailUseCase.Params>(observer) {
 
     override fun buildUseCaseSingle(params: Params): Single<TextDetail> {
         return tempStorageRepo.storeText(params.text)

--- a/service/src/main/java/be/hogent/faith/service/usecases/detail/textDetail/LoadTextDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detail/textDetail/LoadTextDetailUseCase.kt
@@ -8,8 +8,8 @@ import io.reactivex.Single
 
 class LoadTextDetailUseCase(
     private val tempStorageRepo: ITemporaryFileStorageRepository,
-    observeScheduler: Scheduler
-) : SingleUseCase<String, LoadTextDetailUseCase.LoadTextParams>(observeScheduler) {
+    observer: Scheduler
+) : SingleUseCase<String, LoadTextDetailUseCase.LoadTextParams>(observer) {
 
     override fun buildUseCaseSingle(params: LoadTextParams): Single<String> {
         return tempStorageRepo.loadTextFromExistingDetail(params.textDetail)

--- a/service/src/main/java/be/hogent/faith/service/usecases/detail/textDetail/OverwriteTextDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detail/textDetail/OverwriteTextDetailUseCase.kt
@@ -12,10 +12,9 @@ import io.reactivex.Scheduler
  */
 class OverwriteTextDetailUseCase(
     private val tempStorageRepo: ITemporaryFileStorageRepository,
-    observeScheduler: Scheduler
-) : CompletableUseCase<OverwriteTextDetailUseCase.Params>(
-    observeScheduler
-) {
+    observer: Scheduler
+) : CompletableUseCase<OverwriteTextDetailUseCase.Params>(observer) {
+
     override fun buildUseCaseObservable(params: Params): Completable {
         return tempStorageRepo.overwriteTextDetail(params.text, params.detail)
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/detailscontainer/DeleteDetailsContainerDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detailscontainer/DeleteDetailsContainerDetailUseCase.kt
@@ -11,10 +11,9 @@ import io.reactivex.Scheduler
 class DeleteDetailsContainerDetailUseCase<T : DetailsContainer>(
     private val backpackRepository: IDetailContainerRepository<T>,
     private val fileStorageRepository: IFileStorageRepository,
-    observeScheduler: Scheduler
-) : CompletableUseCase<DeleteDetailsContainerDetailUseCase.Params>(
-    observeScheduler
-) {
+    observer: Scheduler
+) : CompletableUseCase<DeleteDetailsContainerDetailUseCase.Params>(observer) {
+
     override fun buildUseCaseObservable(params: Params): Completable {
         return Completable.mergeArray(
             backpackRepository.deleteDetail(params.detail),

--- a/service/src/main/java/be/hogent/faith/service/usecases/detailscontainer/LoadDetailFileUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/detailscontainer/LoadDetailFileUseCase.kt
@@ -13,8 +13,8 @@ class LoadDetailFileUseCase<Container : DetailsContainer>(
     private val storageRepo: IFileStorageRepository,
     private val containerRepository: IDetailContainerRepository<Container>,
     private val detailContainerEncryptionService: IDetailContainerEncryptionService<Container>,
-    observeScheduler: Scheduler
-) : CompletableUseCase<LoadDetailFileUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : CompletableUseCase<LoadDetailFileUseCase.Params>(observer) {
 
     override fun buildUseCaseObservable(params: Params): Completable {
         if (storageRepo.setFileIfReady(params.detail, params.container)) {

--- a/service/src/main/java/be/hogent/faith/service/usecases/event/DeleteEventDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/event/DeleteEventDetailUseCase.kt
@@ -7,8 +7,8 @@ import io.reactivex.Completable
 import io.reactivex.Scheduler
 
 class DeleteEventDetailUseCase(
-    observeScheduler: Scheduler
-) : CompletableUseCase<DeleteEventDetailUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : CompletableUseCase<DeleteEventDetailUseCase.Params>(observer) {
 
     override fun buildUseCaseObservable(params: Params): Completable {
         return Completable.fromAction {

--- a/service/src/main/java/be/hogent/faith/service/usecases/event/GetEventsUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/event/GetEventsUseCase.kt
@@ -8,6 +8,7 @@ import be.hogent.faith.service.usecases.base.FlowableUseCase
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.Scheduler
+import io.reactivex.schedulers.Schedulers
 
 /**
  * Returns all the events associated with a user. The files belonging to  these events are not guaranteed
@@ -16,8 +17,9 @@ import io.reactivex.Scheduler
 class GetEventsUseCase(
     private val eventRepository: IEventRepository,
     private val eventEncryptionService: IEventEncryptionService,
-    observeScheduler: Scheduler
-) : FlowableUseCase<List<Event>, GetEventsUseCase.Params>(observeScheduler) {
+    observer: Scheduler,
+    subscriber: Scheduler = Schedulers.io()
+) : FlowableUseCase<List<Event>, GetEventsUseCase.Params>(observer, subscriber) {
 
     override fun buildUseCaseObservable(params: Params): Flowable<List<Event>> {
         return eventRepository.getAll()

--- a/service/src/main/java/be/hogent/faith/service/usecases/event/SaveEmotionAvatarUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/event/SaveEmotionAvatarUseCase.kt
@@ -13,9 +13,9 @@ import io.reactivex.Scheduler
  */
 class SaveEmotionAvatarUseCase(
     private val tempStorageRepo: ITemporaryFileStorageRepository,
-    observeScheduler: Scheduler
+    observer: Scheduler
 ) : CompletableUseCase<SaveEmotionAvatarUseCase.Params>(
-    observeScheduler
+    observer
 ) {
     override fun buildUseCaseObservable(params: Params): Completable {
         return Completable.fromSingle(

--- a/service/src/main/java/be/hogent/faith/service/usecases/event/SaveEventDetailUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/event/SaveEventDetailUseCase.kt
@@ -9,8 +9,8 @@ import io.reactivex.Scheduler
 
 class SaveEventDetailUseCase(
     private val tempStorageRepo: ITemporaryFileStorageRepository,
-    observeScheduler: Scheduler
-) : CompletableUseCase<SaveEventDetailUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : CompletableUseCase<SaveEventDetailUseCase.Params>(observer) {
 
     override fun buildUseCaseObservable(params: Params): Completable {
         if (params.event.details.contains(params.detail)) {

--- a/service/src/main/java/be/hogent/faith/service/usecases/event/SaveEventUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/event/SaveEventUseCase.kt
@@ -14,8 +14,8 @@ open class SaveEventUseCase(
     private val eventEncryptionService: IEventEncryptionService,
     private val filesStorageRepository: IFileStorageRepository,
     private val eventRepository: IEventRepository,
-    observeScheduler: Scheduler
-) : CompletableUseCase<SaveEventUseCase.Params>(observeScheduler) {
+    observer: Scheduler
+) : CompletableUseCase<SaveEventUseCase.Params>(observer) {
 
     private var params: Params? = null
 

--- a/service/src/main/java/be/hogent/faith/service/usecases/user/CreateUserUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/user/CreateUserUseCase.kt
@@ -10,6 +10,7 @@ import be.hogent.faith.service.repositories.IUserRepository
 import be.hogent.faith.service.usecases.base.CompletableUseCase
 import io.reactivex.Completable
 import io.reactivex.Scheduler
+import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 
 class CreateUserUseCase(
@@ -20,8 +21,8 @@ class CreateUserUseCase(
     private val backpackEncryptionService: IDetailContainerEncryptionService<Backpack>,
     private val cinemaEncryptionService: IDetailContainerEncryptionService<Backpack>,
     observer: Scheduler,
-    private val subscriber: Scheduler
-) : CompletableUseCase<CreateUserUseCase.Params>(observer) {
+    subscriber: Scheduler = Schedulers.io()
+) : CompletableUseCase<CreateUserUseCase.Params>(observer, subscriber) {
 
     override fun buildUseCaseObservable(params: Params): Completable {
         val createUser = authManager.register("${params.username}@faith.be", params.password)

--- a/service/src/main/java/be/hogent/faith/service/usecases/user/IsUsernameUniqueUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/user/IsUsernameUniqueUseCase.kt
@@ -11,7 +11,7 @@ class IsUsernameUniqueUseCase(
 ) : SingleUseCase<Boolean, IsUsernameUniqueUseCase.Params>(observer) {
 
     override fun buildUseCaseSingle(params: Params): Single<Boolean> {
-        if (params.username.isNullOrBlank())
+        if (params.username.isBlank())
             return Single.error(RuntimeException("username moet ingevuld zijn"))
         return authManager.isUsernameUnique(params.username + "@faith.be")
     }

--- a/service/src/main/java/be/hogent/faith/service/usecases/user/LogoutUserUseCase.kt
+++ b/service/src/main/java/be/hogent/faith/service/usecases/user/LogoutUserUseCase.kt
@@ -7,8 +7,8 @@ import io.reactivex.Scheduler
 
 class LogoutUserUseCase(
     private val authManager: IAuthManager,
-    observeScheduler: Scheduler
-) : CompletableUseCase<Void?>(observeScheduler) {
+    observer: Scheduler
+) : CompletableUseCase<Void?>(observer) {
 
     override fun buildUseCaseObservable(params: Void?): Completable {
         return authManager.signOut()

--- a/service/src/test/java/be/hogent/faith/service/usecases/GetUserUseCaseTest.kt
+++ b/service/src/test/java/be/hogent/faith/service/usecases/GetUserUseCaseTest.kt
@@ -17,6 +17,7 @@ import io.mockk.verify
 import io.reactivex.Flowable
 import io.reactivex.Scheduler
 import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -37,7 +38,8 @@ class GetUserUseCaseTest {
             eventRepository,
             eventEncryptionService,
             authManager,
-            mockk<Scheduler>()
+            mockk<Scheduler>(),
+            Schedulers.trampoline()
         )
     }
 

--- a/service/src/test/java/be/hogent/faith/service/usecases/backpack/GetBackPackDataUseCaseTest.kt
+++ b/service/src/test/java/be/hogent/faith/service/usecases/backpack/GetBackPackDataUseCaseTest.kt
@@ -26,8 +26,8 @@ class GetBackPackDataUseCaseTest {
         getBackPackDataUseCase = GetDetailsContainerDataUseCase<Backpack>(
             containerRepository,
             containerEncryptionService,
-            observeScheduler = mockk(),
-            subscribeScheduler = Schedulers.trampoline()
+            observer = mockk(),
+            subscriber = Schedulers.trampoline()
         )
     }
 

--- a/service/src/test/java/be/hogent/faith/service/usecases/event/DeleteEventDetailUseCaseTest.kt
+++ b/service/src/test/java/be/hogent/faith/service/usecases/event/DeleteEventDetailUseCaseTest.kt
@@ -19,7 +19,7 @@ class DeleteEventDetailUseCaseTest {
     @Before
     fun setUp() {
         event.addDetail(detail)
-        useCase = DeleteEventDetailUseCase(observeScheduler = mockk())
+        useCase = DeleteEventDetailUseCase(observer = mockk())
     }
 
     @After


### PR DESCRIPTION
This is an issue that also showed itself in other use cases that did
network calls: when building observables in the use case they will use
the main thread as subscriber by default, even though in the base Use
case the IO scheduler is defined as the subscriber.

The fix is to specifically mention the IO scheduler when building the
observables that are part of the use case. To do this in a clean way,
the subscriber is now also passed as a constructor parameter for all use
cases.
As to not have to redefine all constructors in the Koin modules, the IO
scheduler was defined as a default argument for the new  subscriber
argument.

In tests, the Schedulers.trampoline() will have to be passed explicitly
to ensure synchronous operation.