### PR TITLE
[feat] Add loader to welcome and cinemafragment

### DIFF
--- a/app/src/main/java/be/hogent/faith/faith/cinema/CinemaCreateVideoFragment.kt
+++ b/app/src/main/java/be/hogent/faith/faith/cinema/CinemaCreateVideoFragment.kt
@@ -22,6 +22,8 @@ import be.hogent.faith.domain.models.detail.VideoDetail
 import be.hogent.faith.faith.details.DetailFinishedListener
 import be.hogent.faith.faith.details.DetailFragment
 import be.hogent.faith.faith.details.DetailsFactory
+import be.hogent.faith.faith.util.dismissDialog
+import be.hogent.faith.faith.util.showLoadingDialog
 import com.google.android.material.datepicker.CalendarConstraints
 import com.google.android.material.datepicker.MaterialDatePicker
 import kotlinx.android.synthetic.main.fragment_cinema_start.btn_cinema_chooseDate
@@ -131,6 +133,14 @@ class CinemaCreateVideoFragment : Fragment(), DetailFragment<FilmDetail> {
         })
         createVideoViewModel.errorMessage.observe(viewLifecycleOwner, Observer { errorMessageId ->
             Toast.makeText(requireContext(), errorMessageId, Toast.LENGTH_SHORT).show()
+        })
+
+        createVideoViewModel.isLoading.observe(viewLifecycleOwner, Observer { isLoading ->
+            if(isLoading){
+                showLoadingDialog()
+            }else{
+                dismissDialog()
+            }
         })
 
         createVideoViewModel.getDetailMetaData.observe(viewLifecycleOwner, Observer {

--- a/app/src/main/java/be/hogent/faith/faith/cityScreen/CityScreenFragment.kt
+++ b/app/src/main/java/be/hogent/faith/faith/cityScreen/CityScreenFragment.kt
@@ -13,6 +13,7 @@ import be.hogent.faith.databinding.FragmentCityScreenBinding
 import be.hogent.faith.faith.UserViewModel
 import be.hogent.faith.faith.di.KoinModules
 import be.hogent.faith.faith.loginOrRegister.registerAvatar.AvatarProvider
+import be.hogent.faith.faith.util.LoadingFragment
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import kotlinx.android.synthetic.main.fragment_city_screen.image_main_avatar
@@ -56,6 +57,8 @@ class CityScreenFragment : Fragment() {
     override fun onStart() {
         super.onStart()
         registerListeners()
+
+
     }
 
     private fun registerListeners() {

--- a/app/src/main/java/be/hogent/faith/faith/loginOrRegister/WelcomeFragment.kt
+++ b/app/src/main/java/be/hogent/faith/faith/loginOrRegister/WelcomeFragment.kt
@@ -12,6 +12,9 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import be.hogent.faith.R
+import be.hogent.faith.faith.util.LoadingFragment
+import be.hogent.faith.faith.util.dismissDialog
+import be.hogent.faith.faith.util.showLoadingDialog
 import be.hogent.faith.faith.util.state.Resource
 import be.hogent.faith.faith.util.state.ResourceState
 import kotlinx.android.synthetic.main.fragment_login.progress
@@ -59,13 +62,14 @@ class WelcomeFragment : Fragment() {
     private fun handleDataStateLogIn(resource: Resource<Unit>) {
         when (resource.status) {
             ResourceState.SUCCESS -> {
+                dismissDialog()
                 navigation!!.userIsLoggedIn()
             }
             ResourceState.LOADING -> {
-                progress.visibility = View.VISIBLE
+                showLoadingDialog()
             }
             ResourceState.ERROR -> {
-                progress.visibility = View.GONE
+                dismissDialog()
                 Toast.makeText(context, resource.message!!, Toast.LENGTH_LONG).show()
             }
         }

--- a/app/src/main/java/be/hogent/faith/faith/util/FragmentExtension.kt
+++ b/app/src/main/java/be/hogent/faith/faith/util/FragmentExtension.kt
@@ -12,3 +12,29 @@ internal fun Fragment.replaceChildFragment(fragment: Fragment, frameId: Int) {
     ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
     ft.commit()
 }
+
+internal fun Fragment.showLoadingDialog(){
+
+    // DialogFragment.show() will take care of adding the fragment
+    // in a transaction.  We also want to remove any currently showing
+    // dialog, so make our own transaction and take care of that here.
+
+    val ft = fragmentManager!!.beginTransaction()
+    val prev = fragmentManager!!.findFragmentByTag("loading_dialog")
+    if (prev != null) {
+        ft.remove(prev)
+    }
+    ft.addToBackStack(null)
+    ft.commit()
+    var loading = LoadingFragment.newInstance()
+    loading.show(requireActivity().supportFragmentManager,"loading_dialog")
+}
+
+internal fun Fragment.dismissDialog(){
+    val ft = fragmentManager!!.beginTransaction()
+    val prev =  fragmentManager!!.findFragmentByTag("loading_dialog")
+    if (prev != null) {
+        ft.remove(prev)
+    }
+    ft.commit()
+}

--- a/app/src/main/java/be/hogent/faith/faith/util/LoadingFragment.kt
+++ b/app/src/main/java/be/hogent/faith/faith/util/LoadingFragment.kt
@@ -1,0 +1,50 @@
+package be.hogent.faith.faith.util
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import be.hogent.faith.R
+
+
+
+/**
+ * A simple [Fragment] subclass which shows a Lottie Animation loading.
+ * Use the [LoadingFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+class LoadingFragment : DialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_loading, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState);
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT));
+        setStyle(STYLE_NO_FRAME, android.R.style.Theme);
+    }
+
+    companion object {
+        /**
+         * Use this factory method to create a new instance.
+
+         * @return A new instance of fragment LoadingFragment.
+         */
+
+        @JvmStatic
+        fun newInstance() =
+            LoadingFragment().apply {
+                arguments = Bundle()
+                isCancelable = false
+            }
+    }
+}

--- a/app/src/main/res/layout/fragment_loading.xml
+++ b/app/src/main/res/layout/fragment_loading.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="@dimen/loader_width"
+    android:layout_height="@dimen/loader_height"
+    android:orientation="vertical">
+    <com.airbnb.lottie.LottieAnimationView
+        android:id="@+id/progressAnimationView"
+        android:layout_width="@dimen/loader_width"
+        android:layout_height="@dimen/loader_height"
+        app:lottie_autoPlay="true"
+        app:lottie_rawRes="@raw/loadingspinner"
+        app:lottie_loop="true"
+        android:layout_centerInParent="true"
+        app:srcCompat="@drawable/vogel"/>
+</RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -24,4 +24,6 @@
     <dimen name="match_constraint">0dp</dimen>
     <dimen name="padding_left">16dp</dimen>
     <dimen name="margin_corner_button">16dp</dimen>
+    <dimen name="loader_width">100dp</dimen>
+    <dimen name="loader_height">100dp</dimen>
 </resources>


### PR DESCRIPTION
### Functionality to show loader:

- Add an extension of a DialogFragment with the bird as a Layout
- Add Extension functions for showing and dismissing the dialog for Base Fragment class

### How to show the Dialog:

- Either call the function directly in the Fragment (e.g. WelcomeFragment)
- Either observe a variable in a ViewModel and react the state changes (e.g. CinemeViewCreateModel and CinemaCreateVideoFragment)

### Cleanup
- Deleted references for old Solution
